### PR TITLE
Enabled the safety button by default

### DIFF
--- a/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -36,3 +36,7 @@ set MIXER quad_x
 set PWM_OUT 1234
 
 set PWM_AUX_OUT 1234
+
+# Enable safety button
+param set-default CBRK_IO_SAFETY 0 
+


### PR DESCRIPTION
Set in `Multicopter default parameters` file, which is included in the `Generic Quadcopter` airframe (px4_firmware/ROMFS/px4fmu_common/init.d/airframes/4001_quad_x). Tested on pixhawk4.